### PR TITLE
5 general update

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/README.md
+++ b/README.md
@@ -2,20 +2,32 @@
 
 WordPress library for generating automatic login URLs for users
 
-### Requirements
+## Requirements
 
-This package is designed to be used on a WordPress site project, not for a plugin or theme. 
+This package is designed to be used on a WordPress site project, not for a plugin or theme.
 
 It needs to be running PHP 5.3 or higher.
 
 It requires the [deliciousbrains/wp-migration](https://github.com/deliciousbrains/wp-migrations) package and so the site will need to be set up to run `wp dbi migrate` as a last stage build step in your deployment process.
 
-### Installation
+It automatically purges expired keys from the database daily, and there are WP-CLI commands to:
+
+1. Manually purge expired keys
+2. Manually generate an auto-login URL
+
+## Installation
 
 - `composer require deliciousbrains/wp-auto-login`
 - Bootstrap the package by adding `\DeliciousBrains\WPAutoLogin\AutoLogin::instance();` to an mu-plugin.
 
-### Use
+There are two parameters you can pass when bootstrapping the package:
+
+ * A custom WP-CLI parent command name (default: `'dbi'`)
+ * A global default expiry time in seconds (default: `10368000` - 120 days)
+
+ These options are explained below.
+
+## Use
 
 To generate a URL that will automatically login a user and land them at a specific URL use this function:
 
@@ -24,3 +36,41 @@ To generate a URL that will automatically login a user and land them at a specif
 The URL will expire in 120 days. However, you can pass the number of seconds the URL will be valid for as the fourth argument, e.g valid for 1 day:
 
 `dbi_get_auto_login_url( $destination_url, $user_id, $query_parms, 86400 );`
+
+You can also specify your own global default for expiry when bootstrapping the package as explained in the "Installation" section above. Use:
+
+`\DeliciousBrains\WPAutoLogin\AutoLogin::instance( 'dbi', <expiry_in_seconds> );`
+
+## WP-CLI
+
+There are two WP-CLI commands.
+
+The commands are added as sub-commands of a parent command. By default the parent command is `dbi` (for example: `wp dbi purge_autologin_keys`). But this can be changed when you bootstrap the package.
+
+For example, doing:
+
+`\DeliciousBrains\WPAutoLogin\AutoLogin::instance( 'autologin', <expiry_in_seconds> );`
+
+will make the commands to be like:
+
+`wp autologin purge_autologin_keys`
+
+### purge_autologin_keys
+
+This command purges any expired keys from the WordPress database. On most sites this happens daily, automatically, with a [WP-Cron task](https://developer.wordpress.org/plugins/cron/). But if you have disabled WP-Cron or want to do this manually for whatever reason then this WP-CLI command lets you do it:
+
+`wp dbi purge_autologin_keys`
+
+### auto_login_url
+
+This command manually generates an auto-login URL that logs a specified user in and sends them to a specified URL.
+
+`wp dbi auto_login_url <user_id> <url> [--expiry=<seconds>]`
+
+The default expiry is used, but you can override it for each link that you create with this command by specifying your own expiry in seconds.
+
+Example:
+
+`wp dbi auto_login_url 12345 https://example.com/dashboard --expiry=21600`
+
+Will generate a link that logs in the user with ID 12345 and takes them to https://example.com/dashboard. The link will be valid for 6 hours.

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,12 @@
   },
   "require": {
     "deliciousbrains/wp-migrations": "^2.0"
+  },
+  "require-dev": {
+	"humanmade/coding-standards": "^1.1"
+  },
+  "scripts": {
+	"phpcbf": "phpcbf --standard=phpcs.xml.dist",
+	"phpcs": "phpcs --standard=phpcs.xml.dist"
   }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset name="Delicious Brains">
+	<!-- Files or directories to check -->
+	<file>.</file>
+
+	<!-- Path to strip from the front of file paths inside reports (displays shorter paths) -->
+	<arg name="basepath" value="." />
+
+	<!-- Use HM Coding Standards -->
+	<rule ref="vendor/humanmade/coding-standards">
+		<!-- Namespace isn't required for all files. -->
+		<exclude name="HM.Functions.NamespacedFunctions.MissingNamespace" />
+		<!-- Ignore rule expecting Namespaced directory. -->
+		<exclude name="HM.Files.NamespaceDirectoryName.NoIncDirectory" />
+		<!-- File name and class name match is not necessary. -->
+		<exclude name="HM.Files.ClassFileName.MismatchedName" />
+		<!-- Ignore class file name rule -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<!-- Ignore rule expecting hyphens in file name. -->
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+		<!-- Don't require file comment header. -->
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+	</rule>
+
+	<!-- Ignore Snake case variables for tests -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase">
+		<exclude-pattern>/tests/*</exclude-pattern>
+	</rule>
+</ruleset>

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -19,14 +19,17 @@ class AutoLogin {
 	protected $expires;
 
 	/**
-	 * @param string $command_name
+	 * Instantiate singleton instance
+	 *
+	 * @param string $command_name  Name to used for WP-CLI command.
+	 * @param int    $expires       Key expiry in seconds - default 4 months.
 	 *
 	 * @return AutoLogin Instance
 	 */
-	public static function instance( $command_name =  'dbi') {
+	public static function instance( $command_name = 'dbi', $expires = 10_368_000 ) {
 		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof AutoLogin ) ) {
 			self::$instance = new AutoLogin();
-			self::$instance->init( $command_name );
+			self::$instance->init( $command_name, $expires );
 		}
 
 		return self::$instance;
@@ -34,15 +37,19 @@ class AutoLogin {
 
 
 	/**
-	 * @param $command_name
+	 * Initialise the singleton instance
+	 *
+	 * @param string $command_name  Name to used for WP-CLI command.
+	 * @param int    $expires       Key expiry in seconds.
 	 */
-	public function init( $command_name ) {
-		$this->expires = DAY_IN_SECONDS * 30 * 4;
+	public function init( $command_name, $expires ) {
 		Migrator::instance();
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( $command_name . ' auto-login-url', Command::class );
 		}
+
+		$this->expires = $expires;
 
 		add_filter( 'dbi_wp_migrations_paths', array( $this, 'add_migration_path' ) );
 		add_action( 'init', array( $this, 'handle_auto_login' ) );

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -121,9 +121,9 @@ class AutoLogin {
 			return;
 		}
 
-		$user_id = $this->get_user_id_for_key( $login_key );
+		$user_id_for_key = $this->get_user_id_for_key( $login_key );
 
-		if ( $user_id === false || $user_id != $user->ID ) {
+		if ( $user_id_for_key === false || $user_id_for_key != $user->ID ) {
 			do_action( 'wp_login_failed', $user->user_login );
 
 			return;

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -107,7 +107,7 @@ class AutoLogin {
 		$login_key = filter_input( INPUT_GET, 'login_key', FILTER_SANITIZE_STRING );
 		$user_id   = filter_input( INPUT_GET, 'user_id', FILTER_VALIDATE_INT );
 
-		if ( empty( $login_key ) || empty( $user_id ) ) {
+		if ( $login_key === false || $login_key === null || $user_id === false || $user_id === null ) {
 			return;
 		}
 
@@ -116,15 +116,15 @@ class AutoLogin {
 			return;
 		}
 
-		$user = new \WP_User( $user_id );
+		$user = get_user_by( 'ID', $user_id );
 
-		if ( ! $user->ID ) {
+		if ( $user === false ) {
 			return;
 		}
 
 		$user_id = $this->get_user_id_for_key( $login_key );
 
-		if ( ! $user_id || $user_id != $user->ID ) {
+		if ( $user_id === false || $user_id != $user->ID ) {
 			do_action( 'wp_login_failed', $user->user_login );
 
 			return;

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -52,14 +52,37 @@ class AutoLogin {
 	public function init( $command_name, $expires ) {
 		Migrator::instance();
 
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			\WP_CLI::add_command( $command_name, Command::class );
-		}
+		$this->register_wpcli_commands( $command_name );
+
+		$this->register_cron_actions();
 
 		$this->expires = $expires;
 
 		add_filter( 'dbi_wp_migrations_paths', array( $this, 'add_migration_path' ) );
 		add_action( 'init', array( $this, 'handle_auto_login' ) );
+	}
+
+	/**
+	 * Registers WP-CLI commands
+	 *
+	 * @param string $command_name The name of the first-level command to register sub-commands under.
+	 *
+	 * @return void
+	 */
+	public function register_wpcli_commands( $command_name ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( $command_name, Command::class );
+		}
+	}
+
+	/**
+	 * Adds cron action hooks
+	 *
+	 * @return void
+	 */
+	public function register_cron_actions() {
+		// We'll make use of the built-in wp_scheduled_delete action.
+		add_action( 'wp_scheduled_delete', array( $this, 'remove_expired_keys' ) );
 	}
 
 	/**

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -192,7 +192,7 @@ class AutoLogin {
 	 *
 	 * @return void
 	 */
-	protected function remove_expired_keys() {
+	public function remove_expired_keys() {
 		AutoLoginKey::delete_legacy_keys();
 		AutoLoginKey::delete_expired_keys();
 	}

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -6,14 +6,21 @@ use DeliciousBrains\WPAutoLogin\Model\AutoLoginKey;
 use DeliciousBrains\WPAutoLogin\CLI\Command;
 use DeliciousBrains\WPMigrations\Database\Migrator;
 
+/**
+ * Main auto-login functionality
+ */
 class AutoLogin {
 
 	/**
+	 * Singleton instance
+	 *
 	 * @var AutoLogin
 	 */
 	private static $instance;
 
 	/**
+	 * Key expiry duration in seconds
+	 *
 	 * @var int
 	 */
 	protected $expires;
@@ -55,12 +62,24 @@ class AutoLogin {
 		add_action( 'init', array( $this, 'handle_auto_login' ) );
 	}
 
+	/**
+	 * Filter to modify paths for migration files for the wp-migrations package
+	 *
+	 * @param string[] $paths  List of paths passed in.
+	 *
+	 * @return string[]
+	 */
 	public function add_migration_path( $paths ) {
 		$paths[] = dirname( __DIR__ ) . '/migrations';
 
 		return $paths;
 	}
 
+	/**
+	 * Action to (possibly) handle login on init hook
+	 *
+	 * @return void
+	 */
 	public function handle_auto_login() {
 		$login_key = filter_input( INPUT_GET, 'login_key', FILTER_SANITIZE_STRING );
 		$user_id   = filter_input( INPUT_GET, 'user_id', FILTER_VALIDATE_INT );

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -53,7 +53,7 @@ class AutoLogin {
 		Migrator::instance();
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			\WP_CLI::add_command( $command_name . ' auto-login-url', Command::class );
+			\WP_CLI::add_command( $command_name, Command::class );
 		}
 
 		$this->expires = $expires;

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -116,22 +116,22 @@ class AutoLogin {
 	}
 
 	/**
-	 * @param string $key
+	 * @param string $key_to_find
 	 *
 	 * @return bool|int
 	 */
-	public function get_user_id_for_key( $key ) {
-		$row = AutoLoginKey::get_by_key( $key );
+	public function get_user_id_for_key( $key_to_find ) {
+		$key = AutoLoginKey::get_by_key( $key_to_find );
 
-		if ( ! $row ) {
+		if ( ! $key ) {
 			return false;
 		}
 
-		if ( mysql2date( 'G', $row->created ) < time() - $this->expires ) {
+		if ( $key->is_expired() ) {
 			return false;
 		}
 
-		return $row->user_id;
+		return $key->user_id;
 	}
 
 	/**
@@ -148,12 +148,13 @@ class AutoLogin {
 			$already_exists = AutoLoginKey::get_by_key( $key );
 		} while ( $already_exists );
 
-
 		$loginkey            = new AutoLoginKey();
 		$loginkey->login_key = $key;
 		$loginkey->user_id   = $user_id;
 		if ( $expires_in ) {
 			$loginkey->expires = gmdate( 'Y-m-d H:i:s', time() + $expires_in );
+		} else {
+			$loginkey->expires = gmdate( 'Y-m-d H:i:s', time() + $this->expires );
 		}
 
 		$result = $loginkey->save();

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -2,8 +2,8 @@
 
 namespace DeliciousBrains\WPAutoLogin;
 
-use DeliciousBrains\WPAutoLogin\Model\AutoLoginKey;
 use DeliciousBrains\WPAutoLogin\CLI\Command;
+use DeliciousBrains\WPAutoLogin\Model\AutoLoginKey;
 use DeliciousBrains\WPMigrations\Database\Migrator;
 
 /**
@@ -42,7 +42,6 @@ class AutoLogin {
 		return self::$instance;
 	}
 
-
 	/**
 	 * Initialise the singleton instance
 	 *
@@ -58,8 +57,8 @@ class AutoLogin {
 
 		$this->expires = $expires;
 
-		add_filter( 'dbi_wp_migrations_paths', array( $this, 'add_migration_path' ) );
-		add_action( 'init', array( $this, 'handle_auto_login' ) );
+		add_filter( 'dbi_wp_migrations_paths', [ $this, 'add_migration_path' ] );
+		add_action( 'init', [ $this, 'handle_auto_login' ] );
 	}
 
 	/**
@@ -82,7 +81,7 @@ class AutoLogin {
 	 */
 	public function register_cron_actions() {
 		// We'll make use of the built-in wp_scheduled_delete action.
-		add_action( 'wp_scheduled_delete', array( $this, 'remove_expired_keys' ) );
+		add_action( 'wp_scheduled_delete', [ $this, 'remove_expired_keys' ] );
 	}
 
 	/**
@@ -111,7 +110,7 @@ class AutoLogin {
 			return;
 		}
 
-		// Limit Login Attempts plugin
+		// Limit Login Attempts plugin.
 		if ( function_exists( 'is_limit_login_ok' ) && ! is_limit_login_ok() ) {
 			return;
 		}
@@ -133,7 +132,7 @@ class AutoLogin {
 		wp_set_auth_cookie( $user->ID );
 		do_action( 'wp_login', $user->user_login, $user );
 
-		$redirect = remove_query_arg( array( 'login_key', 'user_id' ) );
+		$redirect = remove_query_arg( [ 'login_key', 'user_id' ] );
 		wp_redirect( $redirect );
 		exit;
 	}
@@ -205,13 +204,13 @@ class AutoLogin {
 	 *
 	 * @return string
 	 */
-	public function create_url( $url, $user_id, $args = array(), $expires_in = null ) {
+	public function create_url( $url, $user_id, $args = [], $expires_in = null ) {
 		$login_key = $this->create_key( $user_id, $expires_in );
 
-		$args = array_merge( array(
+		$args = array_merge( [
 			'login_key' => $login_key,
 			'user_id'   => $user_id,
-		), $args );
+		], $args );
 
 		return add_query_arg( $args, $url );
 	}

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -141,8 +141,6 @@ class AutoLogin {
 	 * @return bool|string
 	 */
 	public function create_key( $user_id, $expires_in = null ) {
-		$this->remove_expired_keys();
-
 		do {
 			$key            = wp_generate_password( 40, false );
 			$already_exists = AutoLoginKey::get_by_key( $key );
@@ -166,12 +164,14 @@ class AutoLogin {
 		return $key;
 	}
 
+	/**
+	 * Purge expired keys from the database.
+	 *
+	 * @return void
+	 */
 	protected function remove_expired_keys() {
-		$expired_date = gmdate( 'Y-m-d H:i:s', ( time() - $this->expires ) );
-		AutoLoginKey::delete_created( $expired_date );
-
-		$now_date = gmdate( 'Y-m-d H:i:s', time() );
-		AutoLoginKey::delete_expires( $now_date );
+		AutoLoginKey::delete_legacy_keys();
+		AutoLoginKey::delete_expired_keys();
 	}
 
 	/**

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -18,6 +18,12 @@ class Command extends \WP_CLI_Command {
 	 * [<url>]
 	 * : URL to add the login key to
 	 *
+	 * [--expiry=<seconds>]
+	 * : Number of seconds until key expires - defaults to 2 days
+	 * ---
+	 * default: 172800
+	 * ---
+	 *
 	 * @param array $args
 	 * @param array $assoc_args
 	 *
@@ -28,14 +34,20 @@ class Command extends \WP_CLI_Command {
 			return \WP_CLI::warning( 'User ID or email address not supplied' );
 		}
 
+		// Validate and fetch user
 		$field = is_numeric( $args[0] ) ? 'ID' : 'email';
 		$user  = get_user_by( $field, $args[0] );
 		if ( ! $user ) {
 			return \WP_CLI::warning( 'User not found' );
 		}
 
+		// Validate expiry
+		if ( ! is_numeric( $assoc_args['expiry'] ) ) {
+			\WP_CLI::error( 'Please specify a numeric value for the expiry.' );
+		}
+
 		$url = empty( $args[1] ) ? home_url() :  $args[1];
-		$key_url = AutoLogin::instance()->create_url( $url, $user->ID );
+		$key_url = AutoLogin::instance()->create_url( $url, $user->ID, array(), $assoc_args['expiry'] );
 
 		return \WP_CLI::success( 'Auto-login URL generated: ' . $key_url );
 	}

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -121,8 +121,8 @@ class AutoLoginKey {
 
 	public function is_expired() {
 		// Handle legacy key for backwards compatibility.
-		if ( $this->is_legacy_key() && $this->has_legacy_key_expired() ) {
-			return false;
+		if ( $this->is_legacy_key() ) {
+			return $this->has_legacy_key_expired();
 		}
 
 		// Handle regular key

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -75,7 +75,9 @@ class AutoLoginKey {
 	 * These keys will have an expiry of '0000-00-00 00:00:00', and will need to be
 	 * expired based on their creation date.
 	 *
-	 * @return void
+	 * @return int|bool  The number of rows deleted, or false if an error occurred.
+	 *                   Note that both false and 0 can be returned so be careful with
+	 *                   comparisons.
 	 */
 	public static function delete_legacy_keys() {
 		global $wpdb;
@@ -84,13 +86,15 @@ class AutoLoginKey {
 
 		$expired_keys_created_before_time = gmdate( 'Y-m-d H:i:s', time() - self::LEGACY_EXPIRY_SECONDS );
 
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE created < %s AND expires = '0000-00-00 00:00:00'", $expired_keys_created_before_time ) );
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE created < %s AND expires = '0000-00-00 00:00:00'", $expired_keys_created_before_time ) );
 	}
 
 	/**
 	 * Static method to delete expired keys from the database.
 	 *
-	 * @return void
+	 * @return int|bool  The number of rows deleted, or false if an error occurred.
+	 *                   Note that both false and 0 can be returned so be careful with
+	 *                   comparisons.
 	 */
 	public static function delete_expired_keys() {
 		global $wpdb;
@@ -99,7 +103,7 @@ class AutoLoginKey {
 
 		$sql_now = gmdate( 'Y-m-d H:i:s', time() );
 
-		$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE expires < %s AND expires != '0000-00-00 00:00:00'", $sql_now ) );
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE expires < %s AND expires != '0000-00-00 00:00:00'", $sql_now ) );
 	}
 
 	public function save() {

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -44,6 +44,11 @@ class AutoLoginKey {
 	 */
 	public $expires;
 
+	/**
+	 * Constructor
+	 *
+	 * @param array $attributes
+	 */
 	public function __construct( $attributes = array() ) {
 		foreach ( $attributes as $key => $value ) {
 			$this->$key = $value;
@@ -53,6 +58,12 @@ class AutoLoginKey {
 		}
 	}
 
+	/**
+	 * Fetches a key object for the specified key.
+	 *
+	 * @param string $key        The key to fetch a record for.
+	 * @return AutoLoginKey|null The key object to return, or null if not found.
+	 */
 	public static function get_by_key( $key ) {
 		global $wpdb;
 
@@ -106,6 +117,11 @@ class AutoLoginKey {
 		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE expires < %s AND expires != '0000-00-00 00:00:00'", $sql_now ) );
 	}
 
+	/**
+	 * Save the current object to the database
+	 *
+	 * @return int|bool
+	 */
 	public function save() {
 		global $wpdb;
 
@@ -119,6 +135,11 @@ class AutoLoginKey {
 		return $wpdb->insert( $wpdb->prefix . self::$table, $data );
 	}
 
+	/**
+	 * Checks if the current key is expired.
+	 *
+	 * @return boolean
+	 */
 	public function is_expired() {
 		// Handle legacy key for backwards compatibility.
 		if ( $this->is_legacy_key() ) {
@@ -133,10 +154,21 @@ class AutoLoginKey {
 		return true;
 	}
 
+	/**
+	 * Checks if the current key is a legacy key
+	 *
+	 * @return boolean
+	 */
 	public function is_legacy_key() {
 		return '0000-00-00 00:00:00' === $this->expires;
 	}
 
+	/**
+	 * Checks if the current key is expired based on the rules for legacy keys.
+	 * The rule is: was the key created more than LEGACY_EXPIRY_SECONDS ago?
+	 *
+	 * @return boolean
+	 */
 	public function has_legacy_key_expired() {
 		// The old version always used 4 months expiry.
 		return ( strtotime( $this->created ) + self::LEGACY_EXPIRY_SECONDS ) < time();

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -100,10 +100,12 @@ class AutoLoginKey {
 			return false;
 		}
 
-		// TODO: MAKE THIS WORK WITH NEW OBJECTS AND DATA
-		if ( mysql2date( 'G', $key->created ) < time() - $this->expires ) {
+		// Handle regular key
+		if ( mysql2date( 'G', $this->expires ) > time() ) {
 			return false;
 		}
+
+		return true;
 	}
 
 	public function is_legacy_key() {


### PR DESCRIPTION
## Background

This is a fairly large refactor of this plugin that was triggered by https://github.com/deliciousbrains/site/issues/1202

This package is potentially a big security risk - we don't want people being able to log in as others. So I'd appreciate a thorough review and test.

Issue 1202 was split into a couple of sub-issues here:

* https://github.com/deliciousbrains/wp-auto-login/issues/4 - to add an option for a single-use link (this is not addressed in this PR)
* https://github.com/deliciousbrains/wp-auto-login/issues/5 - where I realised that I couldn't just reduce the expiry in the DBI site's code because this plugin didn't work properly and it needed more work to fix it.

This PR is for issue #5 and does NOT include the single-use links feature.

Resolves #5 

## Changes

At high level I did the following:

1. The code has two modes: default expiry time and specified expiry time. The old code did not set expiry dates for default expiry and depended on the creation date of the key instead. It only set a specific expiry date if an expiry time was given. So I made it ALWAYS set the expiry.
2. Expiry checks are now done against the expiry date/time set. HOWEVER, for backwards compatibility it will still do the creation date check if the date/time is zero.
3. The code that purges expired keys was also modified to work with the new logic.
4. We also moved the purge code to a WP-CLI command and made it work with wp-cron.

The detailed list of what I did was:

* Put an expiry in the database for all keys generated, whether they use the default expiry or a specified expiry
* Update logic to check against expiry column in DB (also check for zero and use the default if necessary)
* For DB cleanup, use the expiry set in the DB (and also check for zero and use the default if necessary)
* Move DB cleanup out of create_key() - create a DB-CLI command AND call that from wp-cron
* Add an expiry length parameter to the instance() instantiator and set this globally for all create_key() calls
* Ensure CLI calls to create URLs can set expiry correctly too
* Update README

## Testing

This is a fairly standalone package. It doesn't depend on much from our theme, but does required the wp-migrations package.

I'd recommend testing from a dev copy of deliciousbrains.com though. You should be able to include it by specifying a local composer repository in `composer.json` (let me know if you don't know how to do this - I don't know what your composer experience is).

I tested by using WP-CLI to create urls:

`wp dbi auto_login_url 27168 https://deliciousbrains.test/my-account`

And then changing the created and expired dates in the database to try out different scenarios, such as:

* Legacy key - expired
* Legacy key - OK
* Normal key - expired
* Normal key - OK
* Invalid user ID in login URL
* Invalid key in login URL
* Various tests for creating keys, making sure the right expiries ended up in the database
