### PR TITLE
Add one-time option for single-use keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It needs to be running PHP 5.3 or higher.
 
 It requires the [deliciousbrains/wp-migration](https://github.com/deliciousbrains/wp-migrations) package and so the site will need to be set up to run `wp dbi migrate` as a last stage build step in your deployment process.
 
+You should also run `wp dbi migrate` after updating the package to make sure you have up to date database tables.
+
 It automatically purges expired keys from the database daily, and there are WP-CLI commands to:
 
 1. Manually purge expired keys
@@ -31,15 +33,19 @@ There are two parameters you can pass when bootstrapping the package:
 
 To generate a URL that will automatically login a user and land them at a specific URL use this function:
 
-`dbi_get_auto_login_url( $destination_url, $user_id, $query_parms );`
+`dbi_get_auto_login_url( $destination_url, $user_id, [$query_params], [$expiry], [$one_time] );`
 
 The URL will expire in 120 days. However, you can pass the number of seconds the URL will be valid for as the fourth argument, e.g valid for 1 day:
 
-`dbi_get_auto_login_url( $destination_url, $user_id, $query_parms, 86400 );`
+`dbi_get_auto_login_url( $destination_url, $user_id, $query_params, 86400 );`
 
 You can also specify your own global default for expiry when bootstrapping the package as explained in the "Installation" section above. Use:
 
 `\DeliciousBrains\WPAutoLogin\AutoLogin::instance( 'dbi', <expiry_in_seconds> );`
+
+There is also an option to generate links that can only be used once:
+
+`dbi_get_auto_login_url( $destination_url, $user_id, $query_parms, null, true );`
 
 ## WP-CLI
 
@@ -74,3 +80,7 @@ Example:
 `wp dbi auto_login_url 12345 https://example.com/dashboard --expiry=21600`
 
 Will generate a link that logs in the user with ID 12345 and takes them to https://example.com/dashboard. The link will be valid for 6 hours.
+
+You can add `--one-time` to generate a single-use link:
+
+`wp dbi auto_login_url 12345 https://example.com/dashboard --one-time`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can also specify your own global default for expiry when bootstrapping the p
 
 There is also an option to generate links that can only be used once:
 
-`dbi_get_auto_login_url( $destination_url, $user_id, $query_parms, null, true );`
+`dbi_get_auto_login_url( $destination_url, $user_id, $query_params, null, true );`
 
 ## WP-CLI
 

--- a/functions.php
+++ b/functions.php
@@ -5,9 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! function_exists( 'dbi_get_auto_login_url' ) ) {
-	function dbi_get_auto_login_url( $url, $user_id, $args = array(), $expires_in = null ) {
+	function dbi_get_auto_login_url( $url, $user_id, $args = array(), $expires_in = null, $one_time = false ) {
 		$autologin = \DeliciousBrains\WPAutoLogin\AutoLogin::instance();
 
-		return $autologin->create_url( $url, $user_id, $args, $expires_in );
+		return $autologin->create_url( $url, $user_id, $args, $expires_in, $one_time );
 	}
 }

--- a/migrations/2021_09_05_add_single_use_to_keys_table.php
+++ b/migrations/2021_09_05_add_single_use_to_keys_table.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace DeliciousBrains\WPMigrations\Database\Migrations;
+
+use DeliciousBrains\WPMigrations\Database\AbstractMigration;
+
+class AddSingleUseToKeysTable extends AbstractMigration {
+
+	public function run() {
+		global $wpdb;
+
+		$wpdb->query( "
+			ALTER TABLE `{$wpdb->prefix}dbrns_auto_login_keys`
+			ADD COLUMN `one_time` tinyint NOT NULL DEFAULT 0;
+		" );
+	}
+}

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -34,7 +34,7 @@ class AutoLogin {
 	 * @return AutoLogin Instance
 	 */
 	public static function instance( $command_name = 'dbi', $expires = 10_368_000 ) {
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof AutoLogin ) ) {
+		if ( ! isset( self::$instance ) || ! ( self::$instance instanceof AutoLogin ) ) {
 			self::$instance = new AutoLogin();
 			self::$instance->init( $command_name, $expires );
 		}

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -157,12 +157,13 @@ class AutoLogin {
 	}
 
 	/**
-	 * @param int      $user_id
-	 * @param null|int $expires_in Seconds
+	 * @param int          $user_id
+	 * @param null|int     $expires_in Seconds
+	 * @param null|boolean $one_time
 	 *
 	 * @return bool|string
 	 */
-	public function create_key( $user_id, $expires_in = null ) {
+	public function create_key( $user_id, $expires_in = null, $one_time = false ) {
 		do {
 			$key            = wp_generate_password( 40, false );
 			$already_exists = AutoLoginKey::get_by_key( $key );
@@ -171,6 +172,7 @@ class AutoLogin {
 		$loginkey            = new AutoLoginKey();
 		$loginkey->login_key = $key;
 		$loginkey->user_id   = $user_id;
+		$loginkey->one_time  = $one_time;
 		if ( $expires_in ) {
 			$loginkey->expires = gmdate( 'Y-m-d H:i:s', time() + $expires_in );
 		} else {
@@ -197,15 +199,16 @@ class AutoLogin {
 	}
 
 	/**
-	 * @param string   $url
-	 * @param int      $user_id
-	 * @param array    $args
-	 * @param null|int $expires_in Seconds
+	 * @param string       $url
+	 * @param int          $user_id
+	 * @param array        $args
+	 * @param null|int     $expires_in Seconds
+	 * @param null|boolean $one_time
 	 *
 	 * @return string
 	 */
-	public function create_url( $url, $user_id, $args = [], $expires_in = null ) {
-		$login_key = $this->create_key( $user_id, $expires_in );
+	public function create_url( $url, $user_id, $args = [], $expires_in = null, $one_time = false ) {
+		$login_key = $this->create_key( $user_id, $expires_in, $one_time );
 
 		$args = array_merge( [
 			'login_key' => $login_key,

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -121,7 +121,9 @@ class AutoLogin {
 			return;
 		}
 
-		$user_id_for_key = $this->get_user_id_for_key( $login_key );
+		$key = AutoLoginKey::get_by_key( $login_key );
+
+		$user_id_for_key = $this->get_user_id_for_key( $key );
 
 		if ( $user_id_for_key === false || $user_id_for_key != $user->ID ) {
 			do_action( 'wp_login_failed', $user->user_login );
@@ -131,6 +133,8 @@ class AutoLogin {
 
 		wp_set_auth_cookie( $user->ID );
 		do_action( 'wp_login', $user->user_login, $user );
+
+		$key->maybe_delete_one_time_key();
 
 		$redirect = remove_query_arg( [ 'login_key', 'user_id' ] );
 		wp_redirect( $redirect );
@@ -142,9 +146,7 @@ class AutoLogin {
 	 *
 	 * @return bool|int
 	 */
-	public function get_user_id_for_key( $key_to_find ) {
-		$key = AutoLoginKey::get_by_key( $key_to_find );
-
+	public function get_user_id_for_key( $key ) {
 		if ( ! $key ) {
 			return false;
 		}

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -44,13 +44,15 @@ class Command extends \WP_CLI_Command {
 			return \WP_CLI::warning( 'User not found' );
 		}
 
-		// Validate expiry
+		// Validate one-time option.
+		$one_time = isset( $assoc_args['one-time'] ) ? (bool) $assoc_args['one-time'] : false;
+
 		if ( ! is_numeric( $assoc_args['expiry'] ) ) {
 			\WP_CLI::error( 'Please specify a numeric value for the expiry.' );
 		}
 
-		$url = empty( $args[1] ) ? home_url() :  $args[1];
-		$key_url = AutoLogin::instance()->create_url( $url, $user->ID, array(), $assoc_args['expiry'], $assoc_args['one-time'] );
+		$url = empty( $args[1] ) ? home_url() : $args[1];
+		$key_url = AutoLogin::instance()->create_url( $url, $user->ID, array(), $assoc_args['expiry'], $one_time );
 
 		return \WP_CLI::success( 'Auto-login URL generated: ' . $key_url );
 	}

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -47,6 +47,7 @@ class Command extends \WP_CLI_Command {
 		// Validate one-time option.
 		$one_time = isset( $assoc_args['one-time'] ) ? (bool) $assoc_args['one-time'] : false;
 
+		// Validate expiry. Note that WP-CLI always provides a default so we don't need an isset check.
 		if ( ! is_numeric( $assoc_args['expiry'] ) ) {
 			\WP_CLI::error( 'Please specify a numeric value for the expiry.' );
 		}

--- a/src/CLI/Command.php
+++ b/src/CLI/Command.php
@@ -23,6 +23,9 @@ class Command extends \WP_CLI_Command {
 	 * ---
 	 * default: 172800
 	 * ---
+
+	 * [--one-time]
+	 * : Make the login key work only once
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -47,7 +50,7 @@ class Command extends \WP_CLI_Command {
 		}
 
 		$url = empty( $args[1] ) ? home_url() :  $args[1];
-		$key_url = AutoLogin::instance()->create_url( $url, $user->ID, array(), $assoc_args['expiry'] );
+		$key_url = AutoLogin::instance()->create_url( $url, $user->ID, array(), $assoc_args['expiry'], $assoc_args['one-time'] );
 
 		return \WP_CLI::success( 'Auto-login URL generated: ' . $key_url );
 	}

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -66,6 +66,8 @@ class AutoLoginKey {
 
 		if ( ! isset( $attributes['one_time'] ) ) {
 			$this->one_time = false;
+		} else {
+			$this->one_time = (bool) $attributes['one_time'];
 		}
 	}
 
@@ -91,29 +93,24 @@ class AutoLoginKey {
 			return null;
 		}
 
-		if ( (bool) $row['one_time'] ) {
-			self::maybe_delete_one_time_key( $key );
-		}
-
 		return new self( $row );
 	}
 
 	/**
-	 * Static method to check if a key is one-time and to delete it from the
-	 * database if it is.
+	 * Check if the key is one-time and to delete it from the database if it is.
 	 *
-	 * @param string $key
+	 * @param AutoLoginKey $key
 	 *
 	 * @return int|bool  The number of rows deleted, or false if an error occurred.
 	 *                   Note that both false and 0 can be returned so be careful with
 	 *                   comparisons.
 	 */
-	public static function maybe_delete_one_time_key( $key ) {
+	public function maybe_delete_one_time_key() {
 		global $wpdb;
 
 		$table = self::$table;
 
-		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE login_key = %s AND one_time = 1", $key ) );
+		return $wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->prefix{$table} WHERE login_key = %s AND one_time = 1", $this->login_key ) );
 	}
 
 	/**

--- a/src/Model/AutoLoginKey.php
+++ b/src/Model/AutoLoginKey.php
@@ -99,8 +99,6 @@ class AutoLoginKey {
 	/**
 	 * Check if the key is one-time and to delete it from the database if it is.
 	 *
-	 * @param AutoLoginKey $key
-	 *
 	 * @return int|bool  The number of rows deleted, or false if an error occurred.
 	 *                   Note that both false and 0 can be returned so be careful with
 	 *                   comparisons.


### PR DESCRIPTION
Resolves #4

Adds an option for a single-use link.

Single use-links will be deleted from the database when they are used.

I've included an option in the WP-CLI command too.

To test I would recommend:

* Clone the repository of this package
* Add a new path repository to your `composer.json`:
```
  "repositories": [
    ....
    {
      "type": "path",
      "url": "/path/to/wp-auto-login"
    }
  ],
```

* Run `composer update deliciousbrains/wp-auto-login`
* Run `wp dbi migrate` to get the new column in the database table
* Use wp-cli to generate links: e.g. `wp dbi auto_login_url 27168 https://deliciousbrains.test/my-account --one-time`
* Check that the link in the database (in the `oiz6q8a_dbrns_auto_login_keys` table) has been generated with the correct expiry and one-time setting
* Copy the link that wp-cli generated, open an incognito/private browsing window in your browser, and paste it in
* Test regular links by changing the expiry in the database and re-testing the link
* One-time links should only work once - that should be easy to test.
* You can also generate links using `wp shell` and then executing something like `dbi_get_auto_login_url( 'https://deliciousbrains.test/', 27168, [], null, true );`
