### PR TITLE
PHP 8 updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,15 @@
     "deliciousbrains/wp-migrations": "^2.0"
   },
   "require-dev": {
-	"humanmade/coding-standards": "^1.1"
+    "humanmade/coding-standards": "^1.1"
   },
   "scripts": {
-	"phpcbf": "phpcbf --standard=phpcs.xml.dist",
-	"phpcs": "phpcs --standard=phpcs.xml.dist"
+    "phpcbf": "phpcbf --standard=phpcs.xml.dist",
+    "phpcs": "phpcs --standard=phpcs.xml.dist"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -236,6 +236,6 @@ class AutoLogin {
 	/**
 	 * As this class is a singleton it should not be able to be unserialized
 	 */
-	protected function __wakeup() {
+	public function __wakeup() {
 	}
 }


### PR DESCRIPTION
- [PHP Warning __wakeup() must have public visibility](https://github.com/deliciousbrains/wp-auto-login/commit/07b03ce827f760f822582d86f0f09fb1d53a4af6)
- `composer.json` formatting cleanup

## Testing instructions

On PHP 8.2+

1. Check for valid `composer.json` with `composer validate`
3. Lint all files with PHP 8 `find . -type f -name "*.php" ! -path "*/vendor/*" -exec php -l {} \; | grep -v "No syntax errors" || true`