### PR TITLE
Fix PHP8 deprectation FILTER_SANITIZE_STRING usage

### DIFF
--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -110,9 +110,7 @@ class AutoLogin {
 			return;
 		}
 
-		if ( $login_key !== null && $login_key !== false ) {
-			$login_key = sanitize_text_field( $login_key );
-		}
+		$login_key = sanitize_text_field( $login_key );
 
 		// Limit Login Attempts plugin.
 		if ( function_exists( 'is_limit_login_ok' ) && ! is_limit_login_ok() ) {

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -104,13 +104,14 @@ class AutoLogin {
 	 */
 	public function handle_auto_login() {
 		$login_key = filter_input( INPUT_GET, 'login_key', FILTER_DEFAULT );
-		if ( $login_key !== null && $login_key !== false ) {
-			$login_key = sanitize_text_field( $login_key );
-		}
 		$user_id   = filter_input( INPUT_GET, 'user_id', FILTER_VALIDATE_INT );
 
 		if ( $login_key === false || $login_key === null || $user_id === false || $user_id === null ) {
 			return;
+		}
+
+		if ( $login_key !== null && $login_key !== false ) {
+			$login_key = sanitize_text_field( $login_key );
 		}
 
 		// Limit Login Attempts plugin.

--- a/src/AutoLogin.php
+++ b/src/AutoLogin.php
@@ -103,7 +103,10 @@ class AutoLogin {
 	 * @return void
 	 */
 	public function handle_auto_login() {
-		$login_key = filter_input( INPUT_GET, 'login_key', FILTER_SANITIZE_STRING );
+		$login_key = filter_input( INPUT_GET, 'login_key', FILTER_DEFAULT );
+		if ( $login_key !== null && $login_key !== false ) {
+			$login_key = sanitize_text_field( $login_key );
+		}
 		$user_id   = filter_input( INPUT_GET, 'user_id', FILTER_VALIDATE_INT );
 
 		if ( $login_key === false || $login_key === null || $user_id === false || $user_id === null ) {


### PR DESCRIPTION
Deprecated in PHP 8.1.0: https://www.php.net/manual/en/filter.constants.php#constant.filter-sanitize-string

Converting to using: [`sanitize_text_field()`](https://developer.wordpress.org/reference/functions/sanitize_text_field/)

- [x] Need to `git tag 1.4.0` upon merging